### PR TITLE
[Fix/111] kakao share upload image error

### DIFF
--- a/src/app/board/[boardId]/_hooks/useSnsShare.ts
+++ b/src/app/board/[boardId]/_hooks/useSnsShare.ts
@@ -1,9 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { isDevMode } from '@/lib/utils/env'
-import { isIOS, isAndroid } from 'react-device-detect'
 import { useSession } from 'next-auth/react'
+import { useEffect } from 'react'
+import { isAndroid, isIOS } from 'react-device-detect'
 
 const useSnsShare = () => {
   const { data: session, status } = useSession()
@@ -21,8 +21,6 @@ const useSnsShare = () => {
       document.body.removeChild(script)
     }
   }, [])
-
-  const [imageUrl, setImageUrl] = useState('')
 
   const shareToKakao = async (boardName: string) => {
     const { Kakao, location } = window
@@ -44,11 +42,20 @@ const useSnsShare = () => {
     }
 
     try {
-      // upload image (로컬 사진은 사용할 수 없으므로 서버에 업로드 후 사용)
-      const res = await Kakao.Share.uploadImage({
-        file: OPTIONS.localImage,
+      // 이미지 파일을 Blob으로 처리하여 File 객체 생성
+      const response = await fetch(OPTIONS.localImage)
+      const blob = await response.blob()
+      const file = new File([blob], 'opengraph-image-v2.png', {
+        type: 'image/png',
       })
-      setImageUrl(res.infos.original.url)
+
+      // upload image (로컬 사진은 사용할 수 없으므로 서버에 업로드 후 사용)
+      const uploadRes = await Kakao.Share.uploadImage({
+        file: [file],
+      })
+
+      const imageUrl = uploadRes.infos.original.url
+
       Kakao.Share.sendDefault({
         objectType: 'feed',
         content: {


### PR DESCRIPTION
### 👀 관련 이슈
#111 

### ✨ 작업한 내용
카카오 공유할 때, open graph 이미지를 사용하려면 서버에 업로드한 후에 url을 받아와서 입력해야 합니다. (로컬 이미지는 사용 불가) 
공식 문서에 따르면 
```
var files = document.getElementById('input-file').files;

Kakao.Share.uploadImage({
  file: files,
})
```
요런 식으로 input에서 가져오는 형식을 지원한다고 해서, 로컬 경로로 가져왔던게 오류가 났던 것 같습니다. 그래서 blob 형식으로 바꿔서 배열로 넣어줬습니다. 오류가 해결되었는지는 배포 후에 확인 가능합니다!

