### PR TITLE
[FEATURE] 5차 MVP 관련 텍스트 수정 및 보드 생성 페이지 뒤로가기 버튼 추가

### DIFF
--- a/src/app/(onboarding)/signup/_components/steps/BirthDtForm.tsx
+++ b/src/app/(onboarding)/signup/_components/steps/BirthDtForm.tsx
@@ -41,7 +41,7 @@ const BirthDtForm = ({
           {'님의\n생일을 입력해주세요!'}
         </div>
         <p className="text-sm text-gray-400">
-          추가 정보를 입력하시면 나에게 딱 맞는 보드 주제를 추천해드려요 :)
+          추가 정보를 입력하시면 나에게 딱 맞는 보드 이름을 추천해드려요 :)
         </p>
 
         <div className="mx-auto mt-14">

--- a/src/app/(onboarding)/signup/_components/steps/GenderForm.tsx
+++ b/src/app/(onboarding)/signup/_components/steps/GenderForm.tsx
@@ -37,7 +37,7 @@ const GenderForm = ({
         {'을 \n 입력해주세요!'}
       </div>
       <p className="text-sm text-gray-400">
-        추가 정보를 입력하시면 나에게 딱 맞는 보드 주제를 추천해드려요 :)
+        추가 정보를 입력하시면 나에게 딱 맞는 보드 이름을 추천해드려요 :)
       </p>
 
       <div className="mx-auto mb-6 flex flex-1 items-center gap-2">

--- a/src/app/board/[boardId]/_components/Tutorial/Tooltips.tsx
+++ b/src/app/board/[boardId]/_components/Tutorial/Tooltips.tsx
@@ -33,7 +33,7 @@ export const Step2Tooltip = () => {
         trianglePos="-bottom-[0%] translate-y-[20%]"
       >
         <Tooltip.Content className="pl-[58px] text-left">
-          <span className="font-semiBold">보드 주제와 맞는 사진</span>
+          <span className="font-semiBold">보드 이름과 맞는 사진</span>
           {`을 올려 \n 보드를 꾸며주세요!`}
         </Tooltip.Content>
         <Tooltip.NextBtn hasNext={false} />

--- a/src/app/board/create/_components/BackButton.tsx
+++ b/src/app/board/create/_components/BackButton.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import React from 'react'
+import ArrowBackIcon from 'public/icons/arrow_back_ios.svg'
+import { useRouter } from 'next/navigation'
+
+const BackButton = () => {
+  const router = useRouter()
+
+  return (
+    <ArrowBackIcon
+      className="absolute left-3 top-5"
+      onClick={() => router.back()}
+    />
+  )
+}
+
+export default BackButton

--- a/src/app/board/create/_components/BoardNameForm.tsx
+++ b/src/app/board/create/_components/BoardNameForm.tsx
@@ -42,7 +42,7 @@ const BoardNameForm = ({ children, createBoard }: BoardNameFormProps) => {
         disabled={isInvalid}
         onClick={() => createBoard(boardName)}
       >
-        완료
+        다음
       </Button>
     </>
   )

--- a/src/app/board/create/_components/BoardNameForm.tsx
+++ b/src/app/board/create/_components/BoardNameForm.tsx
@@ -24,7 +24,7 @@ const BoardNameForm = ({ children, createBoard }: BoardNameFormProps) => {
     <>
       <div>
         <div className="py-9 text-center text-xl font-thin leading-8 text-gray-900">
-          보드 주제를 정해주세요!
+          보드 이름을 정해주세요!
         </div>
         <TextInput
           errorMessage={errorMessage}

--- a/src/app/board/create/page.tsx
+++ b/src/app/board/create/page.tsx
@@ -4,6 +4,7 @@ import { postBoard } from '@/lib'
 import { revalidateTag } from 'next/cache'
 import { redirect } from 'next/navigation'
 import BoardNameRecommendations from '@/app/board/create/_components/BoardNameRecommendations'
+import BackButton from '@/app/board/create/_components/BackButton'
 import BoardAvailabilityCheckModal from './_components/BoardAvailabilityCheckModal'
 import BoardNameForm from './_components/BoardNameForm'
 
@@ -20,7 +21,8 @@ const CreateBoardPage = () => {
     redirect(`/board/${boardId}`)
   }
   return (
-    <div className="flex h-dvh flex-col items-center justify-between px-5">
+    <div className="relative flex h-dvh flex-col items-center justify-between px-5">
+      <BackButton />
       <Image
         src={PolaboLogo}
         alt="logo"

--- a/src/app/mypage/boards/_components/BoardList/BoardEditPopup.tsx
+++ b/src/app/mypage/boards/_components/BoardList/BoardEditPopup.tsx
@@ -21,7 +21,7 @@ const BoardEditPopup = ({
           className="border-b border-b-gray-300 py-2 pl-[22px] text-sm text-gray-950"
           onClick={clickChangeName}
         >
-          <span>보드 주제 수정하기</span>
+          <span>보드 이름 수정하기</span>
         </div>
         <div
           className="py-2 pl-[22px] text-sm text-negative"

--- a/src/app/mypage/boards/_components/BoardList/ChangeBoardNameModal.tsx
+++ b/src/app/mypage/boards/_components/BoardList/ChangeBoardNameModal.tsx
@@ -49,7 +49,7 @@ const ChangeBoardNameModal = ({
     >
       <Modal.CenterModal icon={<ClipIcon className="translate-y-2" />}>
         <Modal.Close />
-        <Modal.Title>보드 주제 수정</Modal.Title>
+        <Modal.Title>보드 이름 수정</Modal.Title>
         <div className="mt-3">
           <TextInput
             errorMessage={`${MAX_BOARD_NAME_LENGTH}자 이내로 입력 가능해요`}


### PR DESCRIPTION
### ✨ 작업한 내용
5차 MVP 관련 텍스트 수정 및 보드 생성 페이지 뒤로가기 버튼 추가했습니다.
- 보드 주제 -> 이름
- 보드 생성 페이지 버튼내 텍스트 "완료" -> "다음"
- 보드 생성 페이지 뒤로가기 버튼 추가

### 📷 스크린샷 또는 GIF
![스크린샷 2024-10-30 오전 12 02 21](https://github.com/user-attachments/assets/a69c3b80-944c-488d-9e52-8ef317522bb6)
