### PR TITLE
[FEATURE] 폴라로이드 메이커/상세보기 메시지 두줄로 수정

### DIFF
--- a/src/components/Polaroid/PolaroidDetail/PolaroidItem.tsx
+++ b/src/components/Polaroid/PolaroidDetail/PolaroidItem.tsx
@@ -25,7 +25,7 @@ const PolaroidItem = ({ polaroid }: PolaroidItemProps) => {
       </div>
       <PolaroidDescription themaKey={polaroid.options.THEMA}>
         <PolaroidMessage
-          className="min-h-6 text-xl"
+          className="max-h-[52px] min-h-[25px] whitespace-normal text-xl leading-6"
           message={polaroid.oneLineMessage}
         />
         <PolaroidNickname

--- a/src/components/Polaroid/PolaroidMaker/PolaroidMessageInput.tsx
+++ b/src/components/Polaroid/PolaroidMaker/PolaroidMessageInput.tsx
@@ -1,9 +1,10 @@
 import { preventKeyboardSubmit } from '@/lib/utils/keyboard'
+import { useEffect, useRef } from 'react'
 
 interface PolaroidMessageInputProps {
   message: string
   maxLength: number
-  changeMessage: (e: React.ChangeEvent<HTMLInputElement>) => void
+  changeMessage: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
 const PolaroidMessageInput = ({
@@ -11,17 +12,29 @@ const PolaroidMessageInput = ({
   maxLength,
   changeMessage,
 }: PolaroidMessageInputProps) => {
+  const ref = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!ref.current) {
+      return
+    }
+
+    ref.current.style.height = 'auto' // 높이를 초기화하여 기존 높이를 제거
+    ref.current.style.height = `${ref.current.scrollHeight}px`
+  }, [message])
+
   return (
-    <div className="text-lg tracking-tight">
-      <input
-        type="text"
+    <div className="tracking-tight">
+      <textarea
+        ref={ref}
         value={message}
         onChange={changeMessage}
         onKeyDown={preventKeyboardSubmit}
-        className="h-[25px] w-full bg-transparent outline-none"
+        className="w-full resize-none bg-transparent text-xl leading-6 outline-none"
         maxLength={maxLength}
         placeholder="눌러서 한줄 문구를 입력하세요"
         name="oneLineMessage"
+        rows={1}
       />
       <p className="text-right text-sm text-gray-400">
         {message.length}/{maxLength}자

--- a/src/components/Polaroid/PolaroidMaker/index.tsx
+++ b/src/components/Polaroid/PolaroidMaker/index.tsx
@@ -31,7 +31,7 @@ interface PolaroidMakerProps {
   themaKey: ThemaKeyType
 }
 
-const MAX_MESSAGE_LENGTH = 20
+const MAX_MESSAGE_LENGTH = 30
 const MAX_FROM_LENGTH = 10
 
 const PolaroidMaker = ({
@@ -69,7 +69,7 @@ const PolaroidMaker = ({
     }
   }
 
-  const handleMessageChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleMessageChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value.length > MAX_MESSAGE_LENGTH) {
       e.target.value = e.target.value.slice(0, MAX_MESSAGE_LENGTH)
     }

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -1,6 +1,8 @@
 import { KeyboardEvent } from 'react'
 
-export const preventKeyboardSubmit = (e: KeyboardEvent<HTMLInputElement>) => {
+export const preventKeyboardSubmit = (
+  e: KeyboardEvent<HTMLInputElement> | KeyboardEvent<HTMLTextAreaElement>,
+) => {
   if (e.key === 'Enter') {
     e.preventDefault()
   }


### PR DESCRIPTION
### 👀 관련 이슈
- https://discord.com/channels/1242477444460576870/1255532970484170904/1304076952780537896

### ✨ 작업한 내용
- 폴라로이드 메이커 - input -> textarea로 수정
- 폴라로이드 상세보기 - 최소, 최대 높이 수정

### 🌀 PR Point
- 수정할 부분 있으면 알려주세요!

### 📷 스크린샷 또는 GIF

| 기능 | 스크린샷 |
| :--: | :------: |
|  폴라로이드 메이커    |   <img width="439" alt="스크린샷 2024-11-10 오후 4 28 50" src="https://github.com/user-attachments/assets/80e598a4-b5f3-473d-a801-2b19dbcbdf29"> |
| 폴라로이드 상세보기 | <img width="439" alt="스크린샷 2024-11-10 오후 4 29 20" src="https://github.com/user-attachments/assets/77233726-f3ba-4336-b0c5-18f3eacc1a73"> |
